### PR TITLE
Implement basic filter learning web service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+data/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 # filterlearner
+
+This project provides a minimal image filter learning web service that relies
+only on Python's standard library. Images must be uploaded in binary PPM (P6)
+format.
+
+## Running the server
+
+```
+python3 filter_server.py
+```
+
+The server listens on port `8000` by default. Navigate to
+`http://localhost:8000/` to access the web interface.
+
+## Features
+
+* **Learn Filter** – Upload an original image and the same image with a filter
+  applied. A simple colour difference filter is computed and stored under the
+  provided name.
+* **Apply Filter** – Upload an image and choose from predefined filters
+  (`invert`, `brighten`, `darken`) or previously learned filters. The server
+  returns the filtered image as a PPM file.
+
+Because no third‑party dependencies are used, only PPM images are supported.

--- a/filter_server.py
+++ b/filter_server.py
@@ -1,0 +1,96 @@
+import os
+import cgi
+from wsgiref.simple_server import make_server
+from wsgiref.util import setup_testing_defaults
+from io import BytesIO
+from image_utils import load_ppm, save_ppm_bytes
+import filters as flt
+
+
+def render_index():
+    filter_names = sorted(flt.all_filters().keys())
+    options = "\n".join(f'<option value="{name}">{name}</option>' for name in filter_names)
+    html = f"""
+<html>
+<head><title>FilterLearner</title></head>
+<body>
+<h1>FilterLearner</h1>
+<h2>Learn Filter</h2>
+<form action="/learn" method="post" enctype="multipart/form-data">
+Name: <input type="text" name="name"><br>
+Original (PPM P6): <input type="file" name="original"><br>
+Filtered (PPM P6): <input type="file" name="filtered"><br>
+<input type="submit" value="Learn">
+</form>
+<h2>Apply Filter</h2>
+<form action="/apply" method="post" enctype="multipart/form-data">
+Filter: <select name="filter">{options}</select><br>
+Image (PPM P6): <input type="file" name="image"><br>
+<input type="submit" value="Apply">
+</form>
+</body>
+</html>
+"""
+    return html.encode('utf-8')
+
+
+def handle_learn(environ):
+    form = cgi.FieldStorage(fp=environ['wsgi.input'], environ=environ)
+    name = form.getfirst('name', '').strip()
+    if not name:
+        return b'Filter name required', '400 Bad Request', 'text/plain'
+    orig_file = form['original']
+    filt_file = form['filtered']
+    if not getattr(orig_file, 'file', None) or not getattr(filt_file, 'file', None):
+        return b'Both images required', '400 Bad Request', 'text/plain'
+    orig_data = orig_file.file.read()
+    filt_data = filt_file.file.read()
+    ow, oh, maxval, orig_pixels = load_ppm(orig_data)
+    fw, fh, _, filt_pixels = load_ppm(filt_data)
+    if ow != fw or oh != fh:
+        return b'Images must be same size', '400 Bad Request', 'text/plain'
+    filter_def = flt.create_difference_filter(orig_pixels, filt_pixels)
+    flt.save_filter(name, filter_def)
+    return b'Filter saved', '200 OK', 'text/plain'
+
+
+def handle_apply(environ):
+    form = cgi.FieldStorage(fp=environ['wsgi.input'], environ=environ)
+    filter_name = form.getfirst('filter', '')
+    filt = flt.all_filters().get(filter_name)
+    if not filt:
+        return b'Unknown filter', '400 Bad Request', 'text/plain'
+    img_file = form['image']
+    if not getattr(img_file, 'file', None):
+        return b'Image required', '400 Bad Request', 'text/plain'
+    img_data = img_file.file.read()
+    w, h, maxval, pixels = load_ppm(img_data)
+    flt.apply_filter(pixels, filt, maxval)
+    out_data = save_ppm_bytes(w, h, maxval, pixels)
+    return out_data, '200 OK', 'image/x-portable-pixmap'
+
+
+def app(environ, start_response):
+    setup_testing_defaults(environ)
+    path = environ.get('PATH_INFO', '/')
+    if environ['REQUEST_METHOD'] == 'GET' and path == '/':
+        data = render_index()
+        start_response('200 OK', [('Content-Type', 'text/html')])
+        return [data]
+    elif environ['REQUEST_METHOD'] == 'POST' and path == '/learn':
+        data, status, ctype = handle_learn(environ)
+    elif environ['REQUEST_METHOD'] == 'POST' and path == '/apply':
+        data, status, ctype = handle_apply(environ)
+    else:
+        status = '404 Not Found'
+        data = b'Not Found'
+        ctype = 'text/plain'
+    start_response(status, [('Content-Type', ctype)])
+    return [data]
+
+
+if __name__ == '__main__':
+    port = int(os.environ.get('PORT', '8000'))
+    with make_server('', port, app) as httpd:
+        print(f'Serving on port {port}...')
+        httpd.serve_forever()

--- a/filters.py
+++ b/filters.py
@@ -1,0 +1,79 @@
+import os
+import json
+
+FILTERS_DIR = os.path.join('data', 'filters')
+
+PREDEFINED = {
+    'invert': {'type': 'invert'},
+    'brighten': {'type': 'brightness', 'amount': 30},
+    'darken': {'type': 'brightness', 'amount': -30},
+}
+
+
+def load_user_filters():
+    filters = {}
+    if os.path.isdir(FILTERS_DIR):
+        for fname in os.listdir(FILTERS_DIR):
+            if fname.endswith('.json'):
+                path = os.path.join(FILTERS_DIR, fname)
+                with open(path, 'r') as f:
+                    filters[os.path.splitext(fname)[0]] = json.load(f)
+    return filters
+
+
+def all_filters():
+    filters = PREDEFINED.copy()
+    filters.update(load_user_filters())
+    return filters
+
+
+def save_filter(name: str, data: dict):
+    os.makedirs(FILTERS_DIR, exist_ok=True)
+    path = os.path.join(FILTERS_DIR, name + '.json')
+    with open(path, 'w') as f:
+        json.dump(data, f)
+
+
+def create_difference_filter(orig_pixels: bytes, filtered_pixels: bytes):
+    if len(orig_pixels) != len(filtered_pixels):
+        raise ValueError('Images must be same size')
+    dr = dg = db = 0
+    count = len(orig_pixels) // 3
+    for i in range(0, len(orig_pixels), 3):
+        dr += filtered_pixels[i] - orig_pixels[i]
+        dg += filtered_pixels[i+1] - orig_pixels[i+1]
+        db += filtered_pixels[i+2] - orig_pixels[i+2]
+    return {
+        'type': 'difference',
+        'dr': dr / count,
+        'dg': dg / count,
+        'db': db / count,
+    }
+
+
+def apply_filter(pixels: bytearray, filter_def: dict, maxval: int):
+    if filter_def['type'] == 'invert':
+        for i in range(len(pixels)):
+            pixels[i] = maxval - pixels[i]
+    elif filter_def['type'] == 'brightness':
+        amt = filter_def.get('amount', 0)
+        for i in range(len(pixels)):
+            val = pixels[i] + amt
+            if val < 0:
+                val = 0
+            if val > maxval:
+                val = maxval
+            pixels[i] = val
+    elif filter_def['type'] == 'difference':
+        dr = filter_def.get('dr', 0)
+        dg = filter_def.get('dg', 0)
+        db = filter_def.get('db', 0)
+        for i in range(0, len(pixels), 3):
+            r = pixels[i] + dr
+            g = pixels[i+1] + dg
+            b = pixels[i+2] + db
+            pixels[i] = int(min(max(r, 0), maxval))
+            pixels[i+1] = int(min(max(g, 0), maxval))
+            pixels[i+2] = int(min(max(b, 0), maxval))
+    else:
+        raise ValueError('Unknown filter type')

--- a/image_utils.py
+++ b/image_utils.py
@@ -1,0 +1,30 @@
+import io
+
+
+def _read_token(f):
+    token = b''
+    ch = f.read(1)
+    while ch and ch.isspace():
+        ch = f.read(1)
+    while ch and not ch.isspace():
+        token += ch
+        ch = f.read(1)
+    return token
+
+
+def load_ppm(data: bytes):
+    """Load binary PPM (P6) image from bytes."""
+    f = io.BytesIO(data)
+    magic = _read_token(f)
+    if magic != b'P6':
+        raise ValueError('Only binary PPM (P6) supported')
+    width = int(_read_token(f))
+    height = int(_read_token(f))
+    maxval = int(_read_token(f))
+    pixels = bytearray(f.read())
+    return width, height, maxval, pixels
+
+
+def save_ppm_bytes(width: int, height: int, maxval: int, pixels: bytes) -> bytes:
+    header = f'P6\n{width} {height}\n{maxval}\n'.encode('ascii')
+    return header + pixels


### PR DESCRIPTION
## Summary
- add README with instructions for the new site
- create a minimal server that learns and applies filters using only the Python standard library
- implement simple PPM image helpers and filter logic
- ignore runtime files

## Testing
- `python3 -m py_compile filter_server.py filters.py image_utils.py`